### PR TITLE
Fix: The single 'compile-template' must return a created package

### DIFF
--- a/src/common-lisp-backend.lisp
+++ b/src/common-lisp-backend.lisp
@@ -447,7 +447,8 @@
                                           (let ((*template-data* env))
                                             (funcall handler env out)))
                                         :supersede t))))
-    (ttable-extend-package ttable package)))
+    (ttable-extend-package ttable package)
+    package))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; compile template


### PR DESCRIPTION
This is needed to give user ability to control over created packages.
