### PR TITLE
Error message in Emacs mode is fixed

### DIFF
--- a/closure-template-html-mode.el
+++ b/closure-template-html-mode.el
@@ -56,8 +56,7 @@
   `((,(rx "{"
           (group (or "literal" "/literal"))
           "}")
-     (1 closure-template-tag-face)
-     (2 font-lock-function-name-face))))
+     (1 closure-template-tag-face))))
 
 (defvar *closure-template-template-keywords*
   `((,(rx "{"


### PR DESCRIPTION
Error message "Error during redisplay: (error No match 2 in highlight (2 font-lock-function-name-face))" is fixed by removing second group highlight specififcation because no secodn group exists in expression
(rx "{"
          (group (or "literal" "/literal"))
          "}")
