### PR TITLE
Make "fetch-property" exported

### DIFF
--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -59,4 +59,5 @@
            #:ttable-extend-package
            #:ttable-sync-package
            #:ensure-ttable-package
-           #:package-ttable))
+           #:package-ttable
+           #:fetch-property))


### PR DESCRIPTION
To handle custom types, for example, structures, without extra
copying clients should be able to implement their own
versions of the "fetch-property". So this "fetch-property" generic function should
be exported from the package.
