### PR TITLE
Fix remainder operator in js backend

### DIFF
--- a/src/javascript-backend.lisp
+++ b/src/javascript-backend.lisp
@@ -48,8 +48,6 @@
            (symbolp (car expr)))
       (let ((key (car expr)))
         (case key
-          (rem (cons 'ps:% (translate-expression backend
-                                                 (cdr expr))))
           (equal (translate-expression backend
                                        (cons '= (cdr expr))))
           (not-equal (list 'ps:!=


### PR DESCRIPTION
Remainder operator is broken in js backend. It generates

'variable'('var') % 2

instead of

$$data$$.var % 2.

Parenscript claims that % is obsolete while rem is works well.
