### PR TITLE
Do not double backslashes

### DIFF
--- a/src/javascript-backend.lisp
+++ b/src/javascript-backend.lisp
@@ -73,7 +73,7 @@
 (defgeneric write-expression (expr out)
   (:documentation "Write expression as JavaScript")
   (:method ((expr string) out)
-    (format out "~S" (%js expr)))
+    (format out "\"~a\"" (%js expr)))
   (:method ((expr integer) out)
     (format out "~d" expr))
   (:method ((expr real) out)


### PR DESCRIPTION
`~S` binds `*print-escape*` to T, and for any backslash resulting from `%js` outputs two backslashes, effectively escaping the backslash.  Using `~A` fixes this.

On a side note, how strong is the reason to escape characters outside the ASCII range?
