### PR TITLE
Make sure the generated package doesn't :use :cl.

### DIFF
--- a/src/common-lisp-backend.lisp
+++ b/src/common-lisp-backend.lisp
@@ -64,7 +64,7 @@
 
 (defun ensure-ttable-package (name &key prototype)
   (or (find-package name)
-      (let* ((package (make-package name))
+      (let* ((package (make-package name :use '()))
              (package-ttable (ensure-symbol "*PACKAGE-TTABLE*" package)))
         (setf (symbol-value package-ttable)
               (make-instance 'ttable :prototype prototype))


### PR DESCRIPTION
Under Clozure, it is impossible to have a template named `atom`, because in Clozure packages inherit from `:cl` unless specifically told not to.

This pull request adds a `:use ()` argument to `make-package` to make sure the generated package is empty.
